### PR TITLE
Require less >= 2.4.0 instead of ~> 2.4.0

### DIFF
--- a/font-awesome-less.gemspec
+++ b/font-awesome-less.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'less-rails'
 
-  spec.add_runtime_dependency 'less', '~> 2.4.0'
+  spec.add_runtime_dependency 'less', '>= 2.4.0'
 end


### PR DESCRIPTION
I need font-awesome-less >= 4.0.3 to use helper method `icon()`. But from 4.0.3 it's force to use `less ~> 2.4.0`.
With less 2.4.0, I must use `less-rails ~> 2.4.0`, that lead to an issue with precompile assets [#71](https://github.com/metaskills/less-rails/issues/71). `less-rails ~> 2.6.0` fixed my issue.
Because that, I decided to use `less >= 2.6.0`. I forked and commit it, and want to pull to your upstream.
Could you consider about any problems if you use less **>=** 2.4.0 and accept my request?